### PR TITLE
fix(save): clear set data after saving

### DIFF
--- a/src/Classes/Database.php
+++ b/src/Classes/Database.php
@@ -861,6 +861,9 @@ class Database implements \IteratorAggregate, \Countable {
 
         Helpers\Data::table($this->name)->put($data);
 
+        // after save, clear all $set data
+        $this->set = new \stdClass();
+
 //         $this->setFields();
     }
 


### PR DESCRIPTION
I notice that the `$set` variable was not cleared after saving the data. It was only reset/cleared by using `setFields()` in https://github.com/Greg0/Lazer-Database/blob/master/src/Classes/Database.php#L135

This PR ensure that the `$set` variable is cleared after calling `save()`