### PR TITLE
feat: Add insert method to force an insert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+.idea

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ use Lazer\Classes\Database as Lazer; // example
 - `addFields()` - append new fields into existing table
 - `deleteFields()` - removing fields from existing table
 - `set()` - get key/value pair array argument to save.
-- `save()` - insert or Update data.
+- `save()` - insert or Update data (automatically detect if it needs an insert or update).
+- `insert()` - force an insert.
 - `delete()` - deleting data.
 - `relations()` - returns array with table relations
 - `config()` - returns object with configuration.
@@ -87,7 +88,7 @@ Lazer::create('table_name', array(
     {field_name} => {field_type}
 ));
 ```
-More informations about field types and usage in PHPDoc
+More information about field types and usage in PHPDoc
 	
 ### Remove database
 ```php

--- a/src/Classes/Database.php
+++ b/src/Classes/Database.php
@@ -838,12 +838,24 @@ class Database implements \IteratorAggregate, \Countable {
     }
 
     /**
-     * Saving inserted or updated data
+     * Insert a row
+     *
+     * @throws LazerException
      */
-    public function save()
+    public function insert()
+    {
+        $this->save(true);
+    }
+
+    /**
+     * Saving inserted or updated data
+     * @param bool $forceInsert
+     * @throws LazerException
+     */
+    public function save($forceInsert = false)
     {
         $data = $this->getData();
-        if (!$this->currentId)
+        if (!$this->currentId || $forceInsert)
         {
             $config = $this->config();
             $config->last_id++;

--- a/tests/src/Classes/DatabaseTest.php
+++ b/tests/src/Classes/DatabaseTest.php
@@ -512,6 +512,26 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
+     * @covers \Lazer\Classes\Database::insert
+     */
+    public function testInsert()
+    {
+        $table        = $this->object->table('users');
+        $table->name  = 'Greg';
+        $table->email = 'greg@example.com';
+        $table->insert();
+
+        $id         = $table->lastId();
+        $user       = $table->find($id);
+        $user->name = 'Gregory';
+        $user->insert();
+
+        $result = $table->find($table->lastId());
+        $this->assertSame('Gregory', $result->name);
+        $this->assertSame('greg@example.com', $result->email);
+    }
+
+    /**
      * @covers \Lazer\Classes\Database::save
      */
     public function testUpdate()


### PR DESCRIPTION
There are times that the `save()` method is not always detect if it need an insert. For example when you run multiple inserts on the same instance but only change one field value. Most of time it will think of an update.

To ensure you insert the data and not updating an existing record you can use `insert()` instead of `save()`